### PR TITLE
bootstrap: add a COPR repo with never dependencies for RHEL 8

### DIFF
--- a/slave/bootstrap.sh
+++ b/slave/bootstrap.sh
@@ -89,6 +89,12 @@ esac
 if [[ $branch =~ RHEL-* ]]; then
     yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+    if [[ $branch == "RHEL-8" ]]; then
+        # Add a COPR repo with never versions of certain dependencies (like kmod).
+        # Should be removed once CentOS 8 is out and is supported by CentOS CI
+        wget -O /etc/yum.repos.d/mrc0mmand-systemd-centos-ci-epel-7.repo https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci/repo/epel-7/mrc0mmand-systemd-centos-ci-epel-7.repo
+    fi
+
     if [[ -f test/test-rpms.txt ]]; then
         yum -y install $(<test/test-rpms.txt)
     fi


### PR DESCRIPTION
As CentOS 8 is still under construction, and dracut won't build
with kmod-devel < 23, let's workaround this, temporarily, using
a custom COPR repo with manually built never dependencies.